### PR TITLE
export: add prefix to source archives so %prep doesn't fail

### DIFF
--- a/kicad-export.sh
+++ b/kicad-export.sh
@@ -15,7 +15,7 @@ TIMESTAMP="$MAIN_REV"
 
 cd kicad.bzr
 echo "Creating kicad-$TIMESTAMP.tar.gz ..."
-git archive --format=tar.gz HEAD > ../kicad-$TIMESTAMP.tar.gz
+git archive --format=tar.gz --prefix=kicad-$TIMESTAMP/ HEAD > ../kicad-$TIMESTAMP.tar.gz
 #bzr export kicad-$TIMESTAMP
 #echo "Creating kicad-$TIMESTAMP.tar.xz ..."
 #tar cJf ../kicad-$TIMESTAMP.tar.xz kicad-$TIMESTAMP
@@ -23,12 +23,12 @@ git archive --format=tar.gz HEAD > ../kicad-$TIMESTAMP.tar.gz
 
 cd ../kicad-library.bzr
 echo "Creating kicad-libraries-$TIMESTAMP.tar.gz ..."
-git archive --format=tar.gz HEAD > ../kicad-libraries-$TIMESTAMP.tar.gz
+git archive --format=tar.gz --prefix=kicad-libraries-$TIMESTAMP/ HEAD > ../kicad-libraries-$TIMESTAMP.tar.gz
 
 
 cd ../kicad-i18n
 echo "Creating kicad-i18n-$TIMESTAMP.tar.gz ..."
-git archive --format=tar.gz HEAD > ../kicad-i18n-$TIMESTAMP.tar.gz
+git archive --format=tar.gz --prefix=kicad-i18n-$TIMESTAMP/ HEAD > ../kicad-i18n-$TIMESTAMP.tar.gz
 
 #TODO(mangelajo): new docs?
 #cd ../kicad-doc.bzr


### PR DESCRIPTION
`%prep` expects source archives to contain a directory.

```
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.Sp88kr
+ umask 022
+ cd /builddir/build/BUILD
+ cd /builddir/build/BUILD
+ rm -rf kicad-r10359.bf59078
+ /usr/bin/tar -xof -
+ /usr/bin/gzip -dc /builddir/build/SOURCES/kicad-r10359.bf59078.tar.gz
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd kicad-r10359.bf59078
/var/tmp/rpm-tmp.Sp88kr: line 37: cd: kicad-r10359.bf59078: No such file or directory
```